### PR TITLE
[fix] Fix import config bug and improve tolerance

### DIFF
--- a/src/QvCoreConfigOperations_Convertion.cpp
+++ b/src/QvCoreConfigOperations_Convertion.cpp
@@ -25,14 +25,15 @@ namespace Qv2ray
             auto vmessConf = JsonFromString(Base64Decode(vmessJsonB64.toString()));
             string ps, add, id, net, type, host, path, tls;
             int port, aid;
-            ps = vmessConf["ps"].toVariant().toString().toStdString();
+            ps = vmessConf.contains("ps") ? vmessConf["ps"].toVariant().toString().toStdString()
+                                : (vmessConf["add"].toVariant().toString().toStdString() + ":" + vmessConf["port"].toVariant().toString().toStdString());
             add = vmessConf["add"].toVariant().toString().toStdString();
             id = vmessConf["id"].toVariant().toString().toStdString();
-            net = vmessConf["net"].toVariant().toString().toStdString();
-            type = vmessConf["type"].toVariant().toString().toStdString();
+            net = vmessConf.contains("net") ? vmessConf["net"].toVariant().toString().toStdString() : "tcp";
+            type = vmessConf.contains("type") ? vmessConf["type"].toVariant().toString().toStdString() : "none";
             host = vmessConf["host"].toVariant().toString().toStdString();
             path = vmessConf["path"].toVariant().toString().toStdString();
-            tls = vmessConf["tls"].toVariant().toString().toStdString();
+            tls = vmessConf.contains("tls") ? vmessConf["tls"].toVariant().toString().toStdString() : "";
             //
             port = vmessConf["port"].toVariant().toInt();
             aid = vmessConf["aid"].toVariant().toInt();

--- a/src/QvCoreConfigOperations_Verification.cpp
+++ b/src/QvCoreConfigOperations_Verification.cpp
@@ -25,21 +25,14 @@ namespace Qv2ray
                 flag = flag && C("port");
                 flag = flag && C("add");
                 // Stream Settings
-                auto net = vmessConf["net"].toString();
+                auto net = C("net") ? vmessConf["net"].toString() : "tcp";
 
-                if (net == "tcp")
-                    flag = flag && C("type");
-                else if (net == "http" || net == "ws")
+                if (net == "http" || net == "ws")
                     flag = flag && C("host") && C("path");
-                else if (net == "kcp")
-                    flag = flag && C("type");
                 else if (net == "domainsocket")
                     flag = flag && C("path");
                 else if (net == "quic")
                     flag = flag && C("host") && C("type") && C("path");
-
-                flag = flag && C("tls");
-                flag = flag && C("net");
 #undef C
                 return flag ? 0 : 1;
             } catch (exception *e) {

--- a/src/ui/w_ImportConfig.cpp
+++ b/src/ui/w_ImportConfig.cpp
@@ -90,7 +90,7 @@ void ImportConfigWindow::on_buttonBox_accepted()
                     return;
 
                 default:
-                    QvMessageBox(this, tr("VMess String Check"), tr("Some internal error occured."));
+                    QvMessageBox(this, tr("VMess String Check"), tr("VMess config is not valid."));
                     return;
             }
         }

--- a/translations/en-US.ts
+++ b/translations/en-US.ts
@@ -113,7 +113,7 @@
     </message>
     <message>
         <location filename="../src/ui/w_ImportConfig.cpp" line="93"/>
-        <source>Some internal error occured.</source>
+        <source>VMess config is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/ru-RU.ts
+++ b/translations/ru-RU.ts
@@ -326,13 +326,13 @@
     </message>
     <message>
       <location filename="../src/ui/w_ImportConfig.cpp" line="69"/>
-      <source>VMess string is not valid</source>
+      <source>VMess string is not valid.</source>
       <translation>Ошибка строки VMess</translation>
     </message>
     <message>
       <location filename="../src/ui/w_ImportConfig.cpp" line="74"/>
-      <source>Some internal error occured</source>
-      <translation>Произошла внутренняя ошибка</translation>
+      <source>VMess config is not valid.</source>
+      <translation>Конфигурация VMess недействительна.</translation>
     </message>
   </context>
   <context>

--- a/translations/zh-CN.ts
+++ b/translations/zh-CN.ts
@@ -325,13 +325,13 @@
     </message>
     <message>
       <location filename="../src/ui/w_ImportConfig.cpp" line="69"/>
-      <source>VMess string is not valid</source>
+      <source>VMess string is not valid.</source>
       <translation>VMess 字符串无效</translation>
     </message>
     <message>
       <location filename="../src/ui/w_ImportConfig.cpp" line="74"/>
-      <source>Some internal error occured</source>
-      <translation>发生了某些内部错误</translation>
+      <source>VMess config is not valid.</source>
+      <translation>VMess 配置无效</translation>
     </message>
   </context>
   <context>


### PR DESCRIPTION
1. `vmessConf["net"]` is used before checked will raise an exception, hence "internal error".
2. The translation source key is `VMess string is not valid.`, not `VMess string is not valid`.
3. Why not add some default values in case of missing.